### PR TITLE
Gary/feature/appointment apis

### DIFF
--- a/src/app/api/appointments/route.js
+++ b/src/app/api/appointments/route.js
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { createClient } from "../../../../utils/supabase/server";
+
+export const GET = async() => {
+  try {
+    const supabase = await createClient();
+
+    const { data } = await supabase.from("appointments").select("*");
+
+    return NextResponse.json({success: true, appointments: data}, {status: 200});
+  } catch (err) {
+    return NextResponse.json({error})
+  }
+}

--- a/src/app/api/appointments/route.js
+++ b/src/app/api/appointments/route.js
@@ -29,3 +29,33 @@ export const DELETE = async(request) => { //handle cancelled appointments
 
 }
 
+
+export const PUT = async(request) => { //Looking to make this useful for both users updating info and admins updating status
+  const supabase = await createClient();
+
+  const body = await request.json(); 
+  const { appointmentId } = body;
+
+  console.log(appointmentId)
+
+  const { data: appointment, error} = await supabase.from('appointments').select("*").eq("id", appointmentId).single()
+
+  if (error) {
+    return NextResponse.json({error}, {status: 404})
+  }
+
+  const appointmentBody = {
+      timeslot: body.timeSlot ? body.timeSlot: appointment.timeSlot,
+      address:  body.address ? body.address : appointment.address,
+      email: body.email ? body.email : appointment.email,
+      status: body.status ? body.status : appointment.status
+  }
+
+  const response = await supabase.from('appointments').update(appointmentBody).eq("id", appointmentId).select("*")
+
+  if (response.error) {
+    return NextResponse.json({error: response.error}, {status: 400})
+  }
+
+  return NextResponse.json({success: true, message: "Appointment successfully updated", appointment: response.data})
+}

--- a/src/app/api/appointments/route.js
+++ b/src/app/api/appointments/route.js
@@ -12,3 +12,20 @@ export const GET = async() => {
     return NextResponse.json({error})
   }
 }
+
+export const DELETE = async(request) => { //handle cancelled appointments
+    const supabase = await createClient();
+
+    const body = await request.json(); 
+    const { id } = body
+
+    const response = await supabase.from("appointments").delete("*").eq("resident_id", id);
+
+    if (response.status != 204) {
+      return NextResponse.json({error: response.error})
+    }
+
+    return NextResponse.json({success: true, message: 'Appointment was successfully deleted'}, {status: 200});
+
+}
+

--- a/src/app/api/user/[userId]/bookAppointment/route.js
+++ b/src/app/api/user/[userId]/bookAppointment/route.js
@@ -27,8 +27,8 @@ export const POST = async(request, { params }) => {
     const appointmentInsertInfo = await supabase.from('appointments').insert({
       resident_id: userId,
       timeslot: body.timeslot,
-      address:  body.address
-      //status is not needed here as it is pending by default
+      address:  body.address,
+      email: user.email,
     })
 
     return NextResponse.json({ message: `Appointment for ${user.name} sucessfully created`, appointmentInsertInfo }, { status: 201 });


### PR DESCRIPTION
# Description
This PR adds GET, PUT, and DELETE apis for appointments. I also made a change to appointments where emails are now apart of the appointment table to be able to contact the user regarding appointment confirmation.

## Related to the following Jira/Trello issue 
https://trello.com/c/bNi0vWAK/24-sharing-the-details-with-city-employees-after-form-submission

## Main changes explained:
- Refactored bookAppointment api to include email of user booking appointment
- Created /api/appointments with GET, PUT and DELETE methods.

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. Using Postman, make a GET request to http://localhost:3000/api/appointments. This should return all appointments in the DB (which is currently 1 due to me testing deletions)
4. Make a PUT request to http://localhost:3000/api/appointments. The body of it should include the id of the appointment you are trying to change and whatever fields you want to update for example- {
    "appointmentId":"32c9c97d-fa91-4bca-bc41-407706f88db8",
    "status": "confirmed"
}. Status can only be confirmed, visited, or pending. It should throw an error if you try to update it to anything else. You should see the appointment info returned with the updated information you made,
5. Make a DELETE request to http://localhost:3000/api/appointments. The body of it should include the id of the appointment to be deleted. Verify that the appointment is no longer apart of the appointment table in the database.
